### PR TITLE
Feat/auth/sign up

### DIFF
--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { T_CVARequiredProperty } from '@/types/cva-props/cva';
 import { VariantProps, cva } from 'class-variance-authority';
 import { FunctionComponent } from 'react';
 /**
@@ -37,34 +38,7 @@ import { FunctionComponent } from 'react';
  *
  */
 
-/*
-Solution 1
-
-  // type T_LevelType = Required<VariantProps<typeof STYLE_LEVEL>>; // Required do optional("?") remove
-
-// type RequiredProperty<T> = { [P in keyof T]: NonNullable<T[P]> }; // null | undefined of property removed indexSignature
-
-// type RequiredProps = RequiredProperty<T_LevelType>;
-*/
-/*
-
-Solution 2. admit
-type T_LevelType = Required<VariantProps<typeof STYLE_LEVEL>>; // Required do optional("?") remove
-
-type RequiredProperty<T> = Required<{ [P in keyof T]: NonNullable<T[P]> }>; // null | undefined of property removed indexSignature
-
-type RequiredProps = RequiredProperty<VariantProps<typeof STYLE_LEVEL>>;
-
-interface I_TitleProps extends RequiredProps {
-  className?: string;
-  text: string;
-}
-
-*/
-
-type RequiredProperty<T> = Required<{ [P in keyof T]: NonNullable<T[P]> }>; // null | undefined of property removed indexSignature
-
-type T_CVAProps = RequiredProperty<VariantProps<typeof STYLE_LEVEL>>;
+type T_CVAProps = T_CVARequiredProperty<VariantProps<typeof STYLE_LEVEL>>;
 
 interface I_TitleProps extends T_CVAProps {
   className?: string;

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -1,13 +1,6 @@
 import { cn } from '@/lib/utils';
-import React, { FunctionComponent } from 'react';
-import { cva } from 'class-variance-authority';
-import clsx from 'clsx';
-interface I_TitleProps {
-  className?: string;
-  level: 1 | 2 | 3 | 4 | 5;
-  text: string;
-}
-
+import { VariantProps, cva } from 'class-variance-authority';
+import { FunctionComponent } from 'react';
 /**
  * 
  * @param  level 1~5까지 들어가면 기본 styling이 적용 됩니다 
@@ -41,38 +34,75 @@ interface I_TitleProps {
     line-height: leading-[1.25rem];
     margin-bottom: mb-7;
   }
- * @returns 
+ *
  */
-const STYLE_LEVEL = cva('', {
+
+/*
+Solution 1
+
+  // type T_LevelType = Required<VariantProps<typeof STYLE_LEVEL>>; // Required do optional("?") remove
+
+// type RequiredProperty<T> = { [P in keyof T]: NonNullable<T[P]> }; // null | undefined of property removed indexSignature
+
+// type RequiredProps = RequiredProperty<T_LevelType>;
+*/
+/*
+
+Solution 2. admit
+type T_LevelType = Required<VariantProps<typeof STYLE_LEVEL>>; // Required do optional("?") remove
+
+type RequiredProperty<T> = Required<{ [P in keyof T]: NonNullable<T[P]> }>; // null | undefined of property removed indexSignature
+
+type RequiredProps = RequiredProperty<VariantProps<typeof STYLE_LEVEL>>;
+
+interface I_TitleProps extends RequiredProps {
+  className?: string;
+  text: string;
+}
+
+*/
+
+type RequiredProperty<T> = Required<{ [P in keyof T]: NonNullable<T[P]> }>; // null | undefined of property removed indexSignature
+
+type T_CVAProps = RequiredProperty<VariantProps<typeof STYLE_LEVEL>>;
+
+interface I_TitleProps extends T_CVAProps {
+  className?: string;
+  text: string;
+}
+
+const STYLE_LEVEL = cva('normal-case mb-7', {
   variants: {
-    FONT_SIZE: {
-      1: 'text-5xl',
-      2: 'text-4xl',
-      3: 'text-3xl',
-      4: 'text-2xl',
-      5: 'text-xl',
-    },
-    LINE_HEIGHT: {
-      1: 'leading-[3rem]',
-      2: 'leading-[2.25rem]',
-      3: 'leading-[1.87rem]',
-      4: 'leading-[1.5rem',
-      5: 'leading-[1.25rem]',
-    },
-    FONT_WEIGHT: {
-      1: 'font-black',
-      2: 'font-black',
-      3: 'font-bold',
-      4: 'font-semibold',
-      5: 'font-medium',
-    },
-    MARGIN_BOTTOM: { 1: 'mb-3.5', 2: 'mb-3.5', 3: 'mb-7', 4: 'mb-7', 5: 'mb-7' },
-    TEXT_TRANSFORM: {
-      1: 'uppercase',
-      2: 'uppercase',
-      3: 'normal-case',
-      4: 'normal-case',
-      5: 'normal-case',
+    level: {
+      1: {
+        fontSize: 'text-5xl',
+        lineHeight: 'leading-[3rem]',
+        fontWeight: 'font-black',
+        marginBottom: 'mb-3.5',
+        textTransFrom: 'uppercase',
+      },
+      2: {
+        fontSize: 'text-4xl',
+        lineHeight: 'leading-[2.25rem]',
+        fontWeight: 'font-black',
+        marginBottom: 'mb-3.5',
+        textTransFrom: 'uppercase',
+      },
+      3: {
+        fontSize: 'text-3xl',
+        lineHeight: 'leading-[1.87rem]',
+        fontWeight: 'font-bold',
+      },
+      4: {
+        fontSize: 'text-2xl',
+        lineHeight: 'leading-[1.5rem]',
+        fontWeight: 'font-semibold',
+      },
+      5: {
+        fontSize: 'text-xl',
+        lineHeight: 'leading-[1.25rem]',
+        fontWeight: 'font-medium',
+      },
     },
   },
 });
@@ -84,11 +114,7 @@ const Title: FunctionComponent<I_TitleProps> = ({ className, level, text }) => {
     <Tag
       className={cn(
         STYLE_LEVEL({
-          FONT_SIZE: level,
-          LINE_HEIGHT: level,
-          FONT_WEIGHT: level,
-          MARGIN_BOTTOM: level,
-          TEXT_TRANSFORM: level,
+          level,
         }),
         className,
       )}

--- a/src/types/cva-props/cva.ts
+++ b/src/types/cva-props/cva.ts
@@ -1,0 +1,5 @@
+/**
+ * @explain cva의 props에 null | undefined를 삭제 하는 generator입니당
+ * @example type T_RemoveNullableCVAProps = T_CVARequiredProperty<VariantProps<typeof CVA_Object>>
+ */
+export type T_CVARequiredProperty<T> = Required<{ [P in keyof T]: NonNullable<T[P]> }>;

--- a/src/types/cva-props/cva.ts
+++ b/src/types/cva-props/cva.ts
@@ -1,5 +1,6 @@
 /**
  * @explain cva의 props에 null | undefined를 삭제 하는 generator입니당
+ * generic에는 반드시 !!! "VariantProps<typeof object>" 로 넣어주세요
  * @example type T_RemoveNullableCVAProps = T_CVARequiredProperty<VariantProps<typeof CVA_Object>>
  */
 export type T_CVARequiredProperty<T> = Required<{ [P in keyof T]: NonNullable<T[P]> }>;


### PR DESCRIPTION

개발자가 만드는 커스텀 공통 UI Component에 내려줄 CVA props에서 null | undefined는 불필요하다 판단 했습니다. 

null | undefined가 없으면 안 넣을 확률이 100%이기에 ... 공통 type을 만들었습니다.  