### PR TITLE
Feat/regist pet

### DIFF
--- a/src/components/common/form/input-file/FileController.tsx
+++ b/src/components/common/form/input-file/FileController.tsx
@@ -26,7 +26,7 @@ interface I_FileControllerProps<
     field: ControllerRenderProps<TFieldValues, TName> & { type: 'file' };
     fieldState: ControllerFieldState;
     formState: UseFormStateReturn<TFieldValues>;
-    base64: unknown;
+    base64: string | null;
     select: () => void;
     remove: () => void;
   }) => React.ReactElement;
@@ -43,7 +43,7 @@ const FileController = <
   const inputRef = useRef<HTMLElement | null>(null);
   const { resetField } = useFormContext();
   const { field, fieldState, formState } = useController({ name, control });
-  const [base64, setBase64] = useState<unknown>(defaultValue ?? null);
+  const [base64, setBase64] = useState<string | null>(defaultValue ?? null);
   const onChange = async (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files?.[0]) {
       setBase64(await getBase64(e.target.files[0]));

--- a/src/components/common/form/input-file/FileController.tsx
+++ b/src/components/common/form/input-file/FileController.tsx
@@ -41,7 +41,7 @@ const FileController = <
 }: I_FileControllerProps<TFieldValues, TName>) => {
   const { control, name, defaultValue } = props;
   const inputRef = useRef<HTMLElement | null>(null);
-  const { setValue } = useFormContext();
+  const { resetField } = useFormContext();
   const { field, fieldState, formState } = useController({ name, control });
   const [base64, setBase64] = useState<unknown>(defaultValue ?? null);
   const onChange = async (e: ChangeEvent<HTMLInputElement>) => {
@@ -65,7 +65,7 @@ const FileController = <
     base64,
     select: () => inputRef.current?.click(),
     remove: () => {
-      setValue(name, null);
+      resetField(name);
       setBase64(null);
     },
     fieldState,

--- a/src/components/regist-pet/RegistPet.tsx
+++ b/src/components/regist-pet/RegistPet.tsx
@@ -36,9 +36,7 @@ const RegistPet = () => {
         <FileController
           name="file"
           control={form.control}
-          render={({ base64, field: { ref, onChange, type, name }, remove, select, ...props }) => (
-            <CustomInput control={form.control} ref={ref} onChange={onChange} type={type} name={name} />
-          )}
+          render={({ base64, register, remove, select, ...props }) => <CustomInput {...register} />}
         />
         {/* <PetForm.input control={form.control} name="file" label="사진" type="file" /> */}
         {/* <PetForm.input control={form.control} name="name" label="이름" />

--- a/src/components/regist-pet/RegistPet.tsx
+++ b/src/components/regist-pet/RegistPet.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { HeartHandshake } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import LayoutForm from '../common/form/form-layout/LayoutForm';
@@ -12,7 +11,7 @@ import PetForm from './pet-form/PetForm';
 const formSchema = z.object({
   // name: z.string(), // 반려동물 이름
   // age: z.string(), // 반려동물 나이
-  file: z.instanceof(File).optional(), // 반려동물 이미지
+  file: z.instanceof(File).nullable(), // 반려동물 이미지
   // el : z.custom<File>((val)=>{
   //   return  val === File
   // })
@@ -37,7 +36,6 @@ const RegistPet = () => {
         <FileController
           name="file"
           control={form.control}
-          defaultValue={<HeartHandshake />}
           render={({ base64, field: { ref, onChange, type, name }, remove, select, ...props }) => (
             <CustomInput control={form.control} ref={ref} onChange={onChange} type={type} name={name} />
           )}

--- a/src/components/regist-pet/RegistPet.tsx
+++ b/src/components/regist-pet/RegistPet.tsx
@@ -1,10 +1,13 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Fragment } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import LayoutForm from '../common/form/form-layout/LayoutForm';
 import LayoutFormHeader from '../common/form/form-layout/layout-form-header/LayoutFormHeader';
 import FileController from '../common/form/input-file/FileController';
-import CustomInput from '../common/form/input-text/CustomInput';
+import { Button } from '../ui/button';
+import { FormControl, FormItem, FormLabel, FormMessage } from '../ui/form';
+import { Input } from '../ui/input';
 import PetForm from './pet-form/PetForm';
 
 // https://github.com/colinhacks/zod#custom-schemas
@@ -39,7 +42,19 @@ const RegistPet = () => {
         <FileController
           name="file"
           control={form.control}
-          render={({ base64, register, remove, select, ...props }) => <CustomInput {...register} />}
+          render={({ base64, register, remove, select, ...props }) => (
+            <Fragment>
+              {base64 && <img src={base64} />}
+              <FormItem>
+                <FormLabel>파일</FormLabel>
+                <FormControl>
+                  <Input {...register} className="hidden" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+              <Button text="삭제" onClick={remove} />
+            </Fragment>
+          )}
         />
         {/* <PetForm.input control={form.control} name="file" label="사진" type="file" /> */}
         {/* <PetForm.input control={form.control} name="name" label="이름" />

--- a/src/components/regist-pet/RegistPet.tsx
+++ b/src/components/regist-pet/RegistPet.tsx
@@ -22,6 +22,9 @@ const formSchema = z.object({
 type T_Schema = z.infer<typeof formSchema>;
 const RegistPet = () => {
   const form = useForm<T_Schema>({
+    defaultValues: {
+      file: null, // zod에서 nullable을 줬습니다. 그리고 null로 default를 해줘야 파일이 선택 안되어있을 때도 zod에서 parsing을 성공합니다. defaultValues를 안해주면 undefined이고, 버튼 클릭시 zod parsing이 실패로 됩니다.
+    },
     resolver: zodResolver(formSchema),
   });
   const submitHandler = (value: T_Schema) => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,11 +7,11 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function getBase64(file: File) {
-  return new Promise((resolve, reject) => {
+  return new Promise<string>((resolve, reject) => {
     const reader = new FileReader();
 
     reader.readAsDataURL(file);
-    reader.onload = () => resolve(reader.result);
+    reader.onload = () => resolve(<string>reader.result);
     reader.onerror = error => reject(error);
   });
 }


### PR DESCRIPTION
기념비적입니다. 

input File을 공통으로 사용하기 위해 최대한 신경써서 만들었습니다. 

FileController를 호출하고 name과 control을 내려주는 것은 필수입니다. 

render props를 명시하고 거기에 안에 콜백함수처럼 인자값과 파일에 사용할 컴포넌트를 넣어두면 미리보기와 form안에 File을 넣을 수 있습니다. 

e.g) render={({ base64, register, remove, select, ...props })=> { <본인이 커스텀?? 보여줄 컴포넌트/> }

-base64 : 이미지 미리보여주기 URL입니다. 
- register : <input에 { ...register } /> 해주세요 
- remove : <Button onClick={remove} /> 해주면 미리보기가 없어지고 file을 삭제합니다. 
- select : 혹시몰라 준비해뒀다. select을 버튼 onClick에 넣어두면 버튼 클릭시 파일 창이 열립니다. 