### PR TITLE
Feat/ssr

### DIFF
--- a/src/api/common/axios_instance.ts
+++ b/src/api/common/axios_instance.ts
@@ -60,7 +60,11 @@ export const axiosAPI = axios.create({
 const axiosInstance_SSR = axios.create({
   baseURL,
 });
-
+/**
+ *
+ * @param ctx ServerSideProps를 사용할 때 호출하는 함수입니다. 각 로그인시 데이터 통신을 할 때 사용할 axios instance 입니다.
+ * @returns
+ */
 export const getAuthorizedAxios = async (ctx: GetServerSidePropsContext) => {
   if (!isServer) return; // 클라이언트에서 실행하지 않음
   if (axiosInstance_SSR.defaults.headers.Authorization || axiosInstance_SSR.defaults.headers.refreshToken) {

--- a/src/api/common/axios_instance.ts
+++ b/src/api/common/axios_instance.ts
@@ -1,4 +1,7 @@
+import { isServer } from '@tanstack/react-query';
 import axios, { InternalAxiosRequestConfig } from 'axios';
+import { GetServerSidePropsContext } from 'next';
+import { getToken } from 'next-auth/jwt';
 import { getSession } from 'next-auth/react';
 
 const baseURL = process.env.NEXT_PUBLIC_SERVER_BASE_URL;
@@ -31,11 +34,15 @@ export const axiosValid_API = axios.create({
 });
 axiosValid_API.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
-    const { accessToken, refreshToken } = await getAuthorizationToken();
-    if (!accessToken || !refreshToken) return config;
+    if (!isServer) {
+      // SSR할 때 Error가 남 getAuthorizationToken안에 있는 getSession함수가 호출이 client에만 되니까 Error가 난다.
+      const { accessToken, refreshToken } = await getAuthorizationToken();
+      if (!accessToken || !refreshToken) return config;
 
-    config.headers.Authorization = `Bearer ${accessToken}`;
-    config.headers.refreshToken = refreshToken;
+      config.headers.Authorization = `Bearer ${accessToken}`;
+      config.headers.refreshToken = refreshToken;
+    }
+
     return config;
   },
   error => {
@@ -49,3 +56,29 @@ axiosValid_API.interceptors.request.use(
 export const axiosAPI = axios.create({
   baseURL,
 });
+
+const axiosInstance_SSR = axios.create({
+  baseURL,
+});
+
+export const getAuthorizedAxios = async (ctx: GetServerSidePropsContext) => {
+  if (!isServer) return; // 클라이언트에서 실행하지 않음
+  if (axiosInstance_SSR.defaults.headers.Authorization || axiosInstance_SSR.defaults.headers.refreshToken) {
+    // axiosInstance_SSR의 default header안에 token이 있으면 그냥 return 합니다.
+    // 의미없는 비동기 통신안하려고 넣어놓은 조건문 입니다.
+    return axiosInstance_SSR;
+  }
+  const req = ctx.req;
+  try {
+    const session = await getToken({ req });
+
+    if (session) {
+      axiosInstance_SSR.defaults.headers.Authorization = `Bearer ${session.accessToken}`;
+      axiosInstance_SSR.defaults.headers.refreshToken = session.refreshToken;
+    }
+  } catch (error) {
+    console.error('Error fetching session:', error);
+  }
+
+  return axiosInstance_SSR;
+};


### PR DESCRIPTION
SSR 시 각 페이지단에서 필요로 하는 보일러 플레이팅이 많습니다. 
뿐만 아니라, 데이터 통신을 해야 하는데 next-auth 서버로부터 먼저 token을 가져와야 하는데 계속해서 페이지가 바뀔때마다 
next-auth 서버 통신 후 

실제 데이터를 통신해야 합니다. 이를 해결하기 위해 여러 각도에서 실험 하고 도전해 본 결과 제가 할 수 있는 만큼의 결과물인 함수 하나가 나왔습니다. 

[ ] getAuthorizedAxios가 없을 때 
```
//  pages/main
export const getServerSideProps: GetServerSideProps = async (ctx: GetServerSidePropsContext) => {
  const queryClient = new QueryClient();
  const session = await getServerSession(ctx.req, ctx.res, authOptions);

  if (session) {
    axiosInstance_SSR.defaults.headers.Authorization = `Bearer ${session.user.accessToken}`;
    axiosInstance_SSR.defaults.headers.refreshToken = `Bearer ${session.user.refreshToken}`;
    await queryClient.prefetchQuery({
      queryKey: ['test'],
      queryFn: async () => {
        const { data } = await axiosInstance_SSR.get('schedule');

        return data;
      },
    });
  }

  return {
    props: {
      dehydratedState: dehydrate(queryClient),
    },
  };
```

[ ] getAuthorizedAxios가 있을 때 

```
export const getServerSideProps: GetServerSideProps = async (ctx: GetServerSidePropsContext) => {
  const queryClient = new QueryClient();
  const axiosInstance = await getAuthorizedAxios(ctx);

  if (axiosInstance)
    await queryClient.prefetchQuery({
      queryKey: ['test'],
      queryFn: async () => {
        const { data } = await axiosInstance.get('post/all/1');
        return data;
      },
    });
  return {
    props: {
      dehydratedState: dehydrate(queryClient),
    },
  };
};
```