### PR TITLE
Feat/ssr

### DIFF
--- a/src/hooks/server/calendar/useFetchCalendarQuery.tsx
+++ b/src/hooks/server/calendar/useFetchCalendarQuery.tsx
@@ -1,6 +1,9 @@
 import { fetchCalendar } from '@/api/calendar/fetch-calendar';
+import { useCalendar } from '@/hooks/client/calendar/useCalendar';
 import useToast from '@/hooks/client/useToast';
 import { RedirectLoginPage } from '@/lib/utils';
+import { setCalendarBindingData } from '@/store/calendar/data-store';
+import { setSchedulePetData } from '@/store/calendar/pet-store';
 import { CalendarDataType } from '@/types/calendar/calendar';
 import { useQuery } from '@tanstack/react-query';
 
@@ -14,9 +17,15 @@ enum MUTATION_QUERY_KEY {
 const useFetchCalendarQuery = () => {
   const router = useRouter();
   const { toast } = useToast();
+  const { updateScheduleModal } = useCalendar();
   const { data, isError, isLoading, error } = useQuery<CalendarDataType[]>({
     queryKey: [MUTATION_QUERY_KEY.SCHEDULE_QUERY],
     queryFn: () => fetchCalendar(),
+    select: data => {
+      setCalendarBindingData(data);
+      setSchedulePetData(data);
+      updateScheduleModal(data);
+    },
   });
 
   useEffect(() => {

--- a/src/hooks/server/calendar/useFetchCalendarQuery.tsx
+++ b/src/hooks/server/calendar/useFetchCalendarQuery.tsx
@@ -25,6 +25,7 @@ const useFetchCalendarQuery = () => {
       setCalendarBindingData(data);
       setSchedulePetData(data);
       updateScheduleModal(data);
+      return data;
     },
   });
 

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -1,27 +1,22 @@
 import { getAuthorizedAxios } from '@/api/common/axios_instance';
 import Calendar from '@/components/calendar/Calendar';
-import { useCalendar } from '@/hooks/client/calendar/useCalendar';
-import { setCalendarBindingData } from '@/store/calendar/data-store';
-import { setSchedulePetData } from '@/store/calendar/pet-store';
-import { CalendarDataType } from '@/types/calendar/calendar';
-import { QueryClient, dehydrate, useQueryClient } from '@tanstack/react-query';
+import { QueryClient, dehydrate } from '@tanstack/react-query';
 import type { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import Head from 'next/head';
-import { useEffect } from 'react';
 
 const CalendarPage = () => {
-  const queryClient = useQueryClient();
-  const schedule = queryClient.getQueryData<CalendarDataType[]>(['SCHEDULE_QUERY']);
-  console.log('🚀 ~ CalendarPage ~ data:', schedule);
-  const { updateScheduleModal } = useCalendar();
+  //const queryClient = useQueryClient();
+  // const schedule = queryClient.getQueryData<CalendarDataType[]>(['SCHEDULE_QUERY']);
+  // console.log('🚀 ~ CalendarPage ~ data:', schedule);
+  // const { updateScheduleModal } = useCalendar();
 
-  useEffect(() => {
-    if (!schedule) return;
+  // useEffect(() => {
+  //   if (!schedule) return;
 
-    setCalendarBindingData(schedule);
-    setSchedulePetData(schedule);
-    updateScheduleModal(schedule);
-  }, [schedule]);
+  //   setCalendarBindingData(schedule);
+  //   setSchedulePetData(schedule);
+  //   updateScheduleModal(schedule);
+  // }, [schedule]);
 
   return (
     <>

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -1,10 +1,12 @@
 import { getAuthorizedAxios } from '@/api/common/axios_instance';
 import Calendar from '@/components/calendar/Calendar';
+import useFetchCalendarQuery from '@/hooks/server/calendar/useFetchCalendarQuery';
 import { QueryClient, dehydrate } from '@tanstack/react-query';
 import type { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import Head from 'next/head';
 
 const CalendarPage = () => {
+  const { isLoading, isError } = useFetchCalendarQuery();
   //const queryClient = useQueryClient();
   // const schedule = queryClient.getQueryData<CalendarDataType[]>(['SCHEDULE_QUERY']);
   // console.log('🚀 ~ CalendarPage ~ data:', schedule);


### PR DESCRIPTION
- issue 
prefetch를 SSR을 통해서 data를 받아온 이후 invalidateQueries로 무효화를 해도 안됐던 이유 

-  문제 원인
invalidateQueries는 stale한 값을 무효화 시킨 후 데이터를 refetching 하는 것입니다. 

SSR은 단순히 prefetch를 한 queryClient를 반환 후 QueryClientProvider에 다시 주입됩니다. 
따라서 데이터를 서버쪽에서 data를 받아왔습니다.   client단에서는 stale한 값인지 모릅니다. 
stale한 값인지 아닌지를 확인해 보면 ['SCHEDULE QUERY']가 inactive라고만 쓰여져 있습니다. 

따라서 stale한 값이 아니라 inactive한 상태이기에 invalidateQueries를 써도 데이터가 refetching 되지를 않습니다. 

그렇다면 ???

어떻게 하면 stale한 값으로 만들 수 있을까?? 라고 의문점이 드는데 useQuery를 사용하여 데이터를 호출 하 '듯' 하면 됩니다. 

코드를 보시면 아시겠지만 uesFetchCalendarQuery를 호출 하는데,
이 함수를 호출해도 서버와 통신하지 않고 prefetching 한 캐싱된 데이터를 꺼내서 줍니다. 즉 서버통신을 하지 않고 caching된

데이터를 넘겨줍니다. 

useQuery를 사용하여 queryFn을 호출하면 데이터 값은 stale한 값으로 변경됩니다. 

stale한 값이다??? invalidateQueries를 사용하면 무효화 및 데이터 refetching이 됩니다. 

